### PR TITLE
Remove redundant Result type parameter labels

### DIFF
--- a/Kekka/Classes/Result<T>/FullyTypedResult.swift
+++ b/Kekka/Classes/Result<T>/FullyTypedResult.swift
@@ -18,8 +18,8 @@ import Foundation
 /// When U conforms to Error type there is a handy conversion function
 /// to coerce to Result<T> type.
 public enum ResultTyped<SuccessValue, FailureValue> {
-    case success(value: SuccessValue)
-    case failure(error: FailureValue)
+    case success(SuccessValue)
+    case failure(FailureValue)
 }
 
 
@@ -27,10 +27,10 @@ public extension ResultTyped where FailureValue: Error {
 
     public var untyped: KResult<SuccessValue> {
         switch self {
-        case let .success(value: v):
-            return .success(value: v)
-        case let .failure(error: v):
-            return .failure(error: v)
+        case let .success(v):
+            return .success(v)
+        case let .failure(v):
+            return .failure(v)
         }
     }
 

--- a/Kekka/Classes/Result<T>/Result.swift
+++ b/Kekka/Classes/Result<T>/Result.swift
@@ -20,8 +20,8 @@ public typealias KResult<T> = Result<T>
  */
 public enum Result<T> {
 
-    case success(value: T)
-    case failure(error: Error)
+    case success(_ value: T)
+    case failure(_ error: Error)
 
 }
 
@@ -49,9 +49,9 @@ public extension Result {
     public func map<U>(_ transform: (T) -> U) -> Result<U> {
         switch self {
         case let .success(v):
-            return .success(value: transform(v))
+            return .success(transform(v))
         case let .failure(e):
-            return .failure(error: e)
+            return .failure(e)
         }
     }
 
@@ -60,7 +60,7 @@ public extension Result {
         case let .success(v):
             return v
         case let .failure(e):
-            return .failure(error: e)
+            return .failure(e)
         }
     }
 
@@ -69,14 +69,14 @@ public extension Result {
 public extension Result {
 
     public var value: T? {
-        if case .success(value: let value) = self {
+        if case .success(let value) = self {
             return value
         }
         return nil
     }
 
     public var error: Error? {
-        if case .failure(error: let error) = self {
+        if case .failure(let error) = self {
             return error
         }
         return nil
@@ -108,9 +108,9 @@ public extension Result {
     public func mapError(_ transform: (Error) -> Error) -> Result<T> {
         switch self {
         case let .success(v):
-            return .success(value: v)
+            return .success(v)
         case let .failure(e):
-            return .failure(error: transform(e))
+            return .failure(transform(e))
         }
     }
 
@@ -122,7 +122,7 @@ public extension Result {
 public extension Error {
 
     public func result<T>() -> Result<T> {
-        return Result<T>.failure(error: self)
+        return Result<T>.failure(self)
     }
 
 }
@@ -133,9 +133,9 @@ extension Result: Equatable where T: Equatable {
 
     public static func == (lhs: Result<T>, rhs: Result<T>) -> Bool {
         switch (lhs, rhs) {
-        case let (.success(value: v1), .success(value: v2)):
+        case let (.success(v1), .success(v2)):
             return v1 == v2
-        case let (.failure(error: e1), .failure(error: e2)):
+        case let (.failure(e1), .failure(e2)):
             return areEqual(e1, e2)
         default:
             return false

--- a/KekkaTests/FullyTypedResultTests.swift
+++ b/KekkaTests/FullyTypedResultTests.swift
@@ -18,25 +18,25 @@ final class FullyTypedResultTests: XCTestCase {
     }
 
     func test_fullyTypedResultCanEmitResultType() {
-        let res = ResultTyped<Int, SomeError>.success(value: 12)
+        let res = ResultTyped<Int, SomeError>.success(12)
         XCTAssertEqual(res.untyped.value, 12)
     }
 
     func test_fullyTypedResultWithErrorCanEmitResultType() {
-        let res = ResultTyped<Int, SomeError>.failure(error: SomeError.divideByZero)
+        let res = ResultTyped<Int, SomeError>.failure(SomeError.divideByZero)
         let error = res.untyped.error as? SomeError
         XCTAssertNotNil(error)
         XCTAssertTrue(error!.isEqual(to: SomeError.divideByZero))
     }
 
     func test_fullyTypedResultCanBeCompared() {
-        XCTAssertEqual(ResultTyped<Int, SomeError>.success(value: 12), .success(value: 12))
-        XCTAssertNotEqual(ResultTyped<Int, SomeError>.success(value: 12), .success(value: 13))
+        XCTAssertEqual(ResultTyped<Int, SomeError>.success(12), .success(12))
+        XCTAssertNotEqual(ResultTyped<Int, SomeError>.success(12), .success(13))
 
-        XCTAssertEqual(ResultTyped<Int, SomeError>.failure(error: SomeError.divideByZero), .failure(error: SomeError.divideByZero))
-        XCTAssertNotEqual(ResultTyped<Int, SomeError>.failure(error: SomeError.divideByZero), .failure(error: SomeError.other))
+        XCTAssertEqual(ResultTyped<Int, SomeError>.failure(SomeError.divideByZero), .failure(SomeError.divideByZero))
+        XCTAssertNotEqual(ResultTyped<Int, SomeError>.failure(SomeError.divideByZero), .failure(SomeError.other))
 
-        XCTAssertNotEqual(ResultTyped<Int, SomeError>.success(value: 12), .failure(error: SomeError.other))
+        XCTAssertNotEqual(ResultTyped<Int, SomeError>.success(12), .failure(SomeError.other))
     }
 
 }

--- a/KekkaTests/FutureTests.swift
+++ b/KekkaTests/FutureTests.swift
@@ -132,11 +132,11 @@ final class Network {
             let session = URLSession(configuration: .default)
             let dataTask = session.dataTask(with: url) { (data, response, error) in
                 if let d = data, error == nil {
-                    aCompletion?(.success(value: d))
+                    aCompletion?(.success(d))
                 } else if let e = error {
-                    aCompletion?(.failure(error: e))
+                    aCompletion?(.failure(e))
                 } else {
-                    aCompletion?(.failure(error: NetworkError.unknown))
+                    aCompletion?(.failure(NetworkError.unknown))
                 }
             }
             dataTask.resume()

--- a/KekkaTests/ResultTExtensionTest.swift
+++ b/KekkaTests/ResultTExtensionTest.swift
@@ -18,19 +18,19 @@ final class ResultTExtensionTests: XCTestCase {
     //MARK:- value? error? extraction
 
     func test_whenResultHasValue_thenItCanBeExtracted() {
-        XCTAssertEqual(Result<Int>.success(value: 12).value, .some(12))
+        XCTAssertEqual(Result<Int>.success(12).value, .some(12))
     }
 
     func test_whenResultHasValue_thenErrorCannotBeExtracted() {
-        XCTAssertNil(Result<Int>.success(value: 12).error)
+        XCTAssertNil(Result<Int>.success(12).error)
     }
 
     func test_whenResultHasError_thenValueCannotBeExtracted() {
-        XCTAssertNil(Result<Int>.failure(error: TError.someError).value)
+        XCTAssertNil(Result<Int>.failure(TError.someError).value)
     }
 
     func test_whenResultHasError_thenValueCanBeExtracted() {
-        let extractedError = Result<Int>.failure(error: TError.someError).error
+        let extractedError = Result<Int>.failure(TError.someError).error
         let eventualType = extractedError as? TError
         XCTAssertEqual(eventualType, TError.someError)
     }
@@ -38,19 +38,19 @@ final class ResultTExtensionTests: XCTestCase {
     // MARK:- succeeded / failed extraction
 
     func test_whenResultHasValue_thenItSucceeded() {
-        XCTAssertTrue(Result<Int>.success(value: 12).succeeded)
+        XCTAssertTrue(Result<Int>.success(12).succeeded)
     }
 
     func test_whenResultHasValue_thenItIsNotFailed() {
-        XCTAssertFalse(Result<Int>.success(value: 12).failed)
+        XCTAssertFalse(Result<Int>.success(12).failed)
     }
 
     func test_whenResultHasError_thenItIsFailed() {
-        XCTAssertTrue(Result<Int>.failure(error: TError.someError).failed)
+        XCTAssertTrue(Result<Int>.failure(TError.someError).failed)
     }
 
     func test_whenResultHasError_thenItIsNotSucceeded() {
-        XCTAssertFalse(Result<Int>.failure(error: TError.someError).succeeded)
+        XCTAssertFalse(Result<Int>.failure(TError.someError).succeeded)
     }
 
     // MARK:- Creation of result from Error types
@@ -67,7 +67,7 @@ final class ResultTExtensionTests: XCTestCase {
             case other(from: String)
         }
 
-        let mappedError = Result<Int>.failure(error: TError.someError).mapError { SomeOtherError.other(from: String(describing: $0)) }
+        let mappedError = Result<Int>.failure(TError.someError).mapError { SomeOtherError.other(from: String(describing: $0)) }
 
         let gotError = mappedError.error as? SomeOtherError
         let expectedError = SomeOtherError.other(from: String(describing: TError.someError))
@@ -81,7 +81,7 @@ final class ResultTExtensionTests: XCTestCase {
             case other(from: String)
         }
 
-        let mappedError = Result<Int>.success(value: 12).mapError {
+        let mappedError = Result<Int>.success(12).mapError {
             SomeOtherError.other(from: String(describing: $0))
         }
 

--- a/KekkaTests/ResultTests.swift
+++ b/KekkaTests/ResultTests.swift
@@ -17,35 +17,35 @@ final class ResultTTests: XCTestCase {
     }
 
     private func divBy0(_ a: Int) -> Result<Int> {
-        return .failure(error: IntError.cannotDivideByZero)
+        return .failure(IntError.cannotDivideByZero)
     }
 
     private func divBy2(_ a: Int) -> Result<Int> {
-        return .success(value: a / 2)
+        return .success(a / 2)
     }
 
     func testWhenResultWithSuccessIsMapped_thenOutputIsResultWithTransformation() {
-        let resultInt = Result<Int>.success(value: 12)
+        let resultInt = Result<Int>.success(12)
         let output = resultInt.map { $0 * 2 }
-        XCTAssertEqual(output, .success(value: 24))
+        XCTAssertEqual(output, .success(24))
     }
 
     func testWhenResultWithFailureIsMapped_thenOutputIsResultWithInitialFailure() {
-        let failInt = Result<Int>.failure(error: IntError.testError)
+        let failInt = Result<Int>.failure(IntError.testError)
         let output = failInt.map { "\($0)" }
-        XCTAssertEqual(output, .failure(error: IntError.testError))
+        XCTAssertEqual(output, .failure(IntError.testError))
     }
 
     func testWhenResultWithFailureIsMappedSuccessively_thenOutputIsResultWithFirstFailure() {
-        let failInt = Result<Int>.failure(error: IntError.testError)
+        let failInt = Result<Int>.failure(IntError.testError)
         let output = failInt.map { $0 * 2 }.map { "\(0)" }.map { $0.uppercased() }
-        XCTAssertEqual(output, .failure(error: IntError.testError))
+        XCTAssertEqual(output, .failure(IntError.testError))
     }
 
     func testWhenIntResultWithSuccessIsMappedToDivBy2_thenItProducesDoubleWrappedResult() {
-        let initialInt = Result<Int>.success(value: 12)
+        let initialInt = Result<Int>.success(12)
         let output = initialInt.map(divBy2)
-        let expected = Result.success(value: Result<Int>.success(value: 6))
+        let expected = Result.success(Result<Int>.success(6))
         XCTAssertEqual(output, expected)
     }
 
@@ -54,57 +54,57 @@ final class ResultTTests: XCTestCase {
     // This is exactly why we have `flatMap`.g
     // The above becomes `intitialInt.flatMap(divBy2).flatMap(divBy2)`
     func testWhenIntResultWithSuccesIsFlatMappedToDivBy2_thenItProducesSingleWrappedResult() {
-        let initialInt = Result<Int>.success(value: 12)
+        let initialInt = Result<Int>.success(12)
         let output = initialInt.flatMap(divBy2)
-        let expected = Result<Int>.success(value: 6)
+        let expected = Result<Int>.success(6)
         XCTAssertEqual(output, expected)
     }
 
     func testWhenIntResultWithSuccessIsFlatMappedToDivBy0ThenDivBy2_thenItProducesResultWithDivFailure() {
-        let initialInt = Result<Int>.success(value: 12)
+        let initialInt = Result<Int>.success(12)
         let output = initialInt.flatMap(divBy2).flatMap(divBy0).flatMap(divBy2)
-        let expected = Result<Int>.failure(error: IntError.cannotDivideByZero)
+        let expected = Result<Int>.failure(IntError.cannotDivideByZero)
         XCTAssertEqual(output, expected)
     }
 
     //MARK:- Equality Tests
 
     func test_whenResultWithSameIntsAreCompared_thenTheyAreEqual() {
-        let a = Result.success(value: 1)
-        let b = Result.success(value: 1)
+        let a = Result.success(1)
+        let b = Result.success(1)
         XCTAssertEqual(a, b)
     }
 
     func test_whenResultWithSameErrorsAreCompared_thenTheyAreEqual() {
-        let a = Result<Int>.failure(error: TestError.cantDivideByTwo)
-        let b = Result<Int>.failure(error: TestError.cantDivideByTwo)
+        let a = Result<Int>.failure(TestError.cantDivideByTwo)
+        let b = Result<Int>.failure(TestError.cantDivideByTwo)
         XCTAssertEqual(a, b)
     }
 
     func test_whenResultWithSameErrorWithAssociatedTypesAreCompared_thenTheyAreEqual() {
-        let a = Result<Int>.failure(error: TestError.unknown("some error"))
-        let b = Result<Int>.failure(error: TestError.unknown("some error"))
+        let a = Result<Int>.failure(TestError.unknown("some error"))
+        let b = Result<Int>.failure(TestError.unknown("some error"))
         XCTAssertEqual(a, b)
     }
 
     func test_whenResultWithErrorsWithDifferentValueForAssocaitedTypesAreCompared_thenTheyAreNotEqual() {
-        XCTAssertNotEqual(Result<Int>.failure(error: TestError.unknown("a")),
-                          Result<Int>.failure(error: TestError.unknown("b")))
+        XCTAssertNotEqual(Result<Int>.failure(TestError.unknown("a")),
+                          Result<Int>.failure(TestError.unknown("b")))
     }
 
     func test_whenResultWithDifferentErrorAreComapred_thenTheyAreNotEqual() {
-        XCTAssertNotEqual(Result<String>.failure(error: TestError.cantDivideByTwo),
-                          Result<String>.failure(error: TestError.cantRepresentComplexNumber))
+        XCTAssertNotEqual(Result<String>.failure(TestError.cantDivideByTwo),
+                          Result<String>.failure(TestError.cantRepresentComplexNumber))
     }
 
     func test_whenResultStringsWithDifferentValuesAreCompared_thenTheyAreNotEqual() {
-        XCTAssertNotEqual(Result<String>.success(value: "hello"),
-                          Result<String>.success(value: "there"))
+        XCTAssertNotEqual(Result<String>.success("hello"),
+                          Result<String>.success("there"))
     }
 
     func test_whenResultWithErrorAndValueAreCompared_thenTheyAreNotEqual() {
-        XCTAssertNotEqual(Result<String>.success(value: "a"),
-                          Result<String>.failure(error: TestError.unknown("a")))
+        XCTAssertNotEqual(Result<String>.success("a"),
+                          Result<String>.failure(TestError.unknown("a")))
     }
 
     enum TestError: Error {


### PR DESCRIPTION
- `Result` type associated value labels are redundant; the meaning is clear from the context
- So, remove them
- [This is also the pattern in other libs](https://github.com/antitypical/Result/blob/master/Result/Result.swift#L16-L19), and also the [upcoming native implementation](https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md)